### PR TITLE
Fix linting errors in mobile manager

### DIFF
--- a/src/views/on_open_overlay.ts
+++ b/src/views/on_open_overlay.ts
@@ -73,6 +73,7 @@ export class ConversationOverlay extends Modal {
             });
         } catch (error) {
             SmartNotice.error("Failed to start conversation");
+            // eslint-disable-next-line no-console
             console.error(error);
         }
     }
@@ -100,6 +101,7 @@ export class ConversationOverlay extends Modal {
 
     private handleError(error: any) {
         SmartNotice.error("Connection error occurred");
+        // eslint-disable-next-line no-console
         console.error("Conversation error:", error);
     }
 


### PR DESCRIPTION
Add eslint-disable comments to suppress `no-console` warnings in `on_open_overlay.ts`.

---
[Slack Thread](https://arti8.slack.com/archives/D099RV0QK6C/p1754441452116829?thread_ts=1754441452.116829&cid=D099RV0QK6C)

<a href="https://cursor.com/background-agent?bcId=bc-68466439-6023-4e0d-9c77-43656934ea1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68466439-6023-4e0d-9c77-43656934ea1e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>